### PR TITLE
Add kerberos authentication

### DIFF
--- a/SCCMSecrets.py
+++ b/SCCMSecrets.py
@@ -9,6 +9,7 @@ from typing_extensions                  import Annotated
 from file_dumper                        import FileDumper
 from policies_dumper                    import PoliciesDumper
 from conf                               import bcolors, ANONYMOUSDP, SCCMDPFileDumpError, SCCMPoliciesDumpError
+from utils.principal_format             import check_principal_format
 
 logger = logging.getLogger(__name__)
 
@@ -47,13 +48,17 @@ def policies(
     if verbose is False: logging.basicConfig(format='%(message)s', level=logging.WARN)
     else: logging.basicConfig(format='%(message)s', level=logging.INFO)
 
+    if machine_name and kerberos:
+        if not check_principal_format(machine_name):
+            logger.warning(f"{bcolors.WARNING}[!] Provided machine name isn't in a valid kerberos principal format{bcolors.ENDC}")
+
     # Arguments format and coherence checks
     if not management_point.startswith('http://') and not management_point.startswith('https://'):
         management_point = f'http://{management_point}'
     if management_point.endswith('/'):
         management_point = management_point[:-1]
     if machine_name is not None and (machine_pass is None and machine_hash is None) \
-        or (machine_pass is not None or machine_hash is not None) and machine_name is None:
+        or (machine_pass is not None or machine_hash is not None) and machine_name is None and not kerberos:
         logger.error(f"{bcolors.FAIL}[!] When providing a machine name, please also provide either the cleartext password or the NT hash{bcolors.ENDC}")
         return
     if machine_hash is not None and len(machine_hash) != 32:
@@ -170,12 +175,16 @@ def files(
     if verbose is False: logging.basicConfig(format='%(message)s', level=logging.WARN)
     else: logging.basicConfig(format='%(message)s', level=logging.INFO)
 
+    if username and kerberos:
+        if not check_principal_format(username):
+            logger.warning(f"{bcolors.WARNING}[!] Provided user name isn't in a valid kerberos principal format{bcolors.ENDC}")
+
     # Arguments format and coherence checks
     if not distribution_point.startswith('http://') and not distribution_point.startswith('https://'):
         distribution_point = f'http://{distribution_point}'
     if distribution_point.endswith('/'):
         distribution_point = distribution_point[:-1]
-    if username is not None and (password is None and hash is None):
+    if username is not None and (password is None and hash is None) and not kerberos:
         logger.error(f"{bcolors.FAIL}[!] When providing a username, please also provide either the cleartext password or the NT hash{bcolors.ENDC}")
         return
     if hash is not None and len(hash) != 32:

--- a/SCCMSecrets.py
+++ b/SCCMSecrets.py
@@ -50,7 +50,8 @@ def policies(
 
     if machine_name and kerberos:
         if not check_principal_format(machine_name):
-            logger.warning(f"{bcolors.WARNING}[!] Provided machine name isn't in a valid kerberos principal format{bcolors.ENDC}")
+            logger.error(f"{bcolors.FAIL}[!] Provided machine name isn't in a valid kerberos principal format{bcolors.ENDC}")
+            return
 
     # Arguments format and coherence checks
     if not management_point.startswith('http://') and not management_point.startswith('https://'):
@@ -177,7 +178,8 @@ def files(
 
     if username and kerberos:
         if not check_principal_format(username):
-            logger.warning(f"{bcolors.WARNING}[!] Provided user name isn't in a valid kerberos principal format{bcolors.ENDC}")
+            logger.error(f"{bcolors.FAIL}[!] Provided user name isn't in a valid kerberos principal format{bcolors.ENDC}")
+            return
 
     # Arguments format and coherence checks
     if not distribution_point.startswith('http://') and not distribution_point.startswith('https://'):

--- a/SCCMSecrets.py
+++ b/SCCMSecrets.py
@@ -38,9 +38,10 @@ def policies(
     registration_sleep: Annotated[int, typer.Option("--registration-sleep", "-rs", help="[Optional] The amount of time, in seconds, that should be waited after registrating a new device. A few minutes is recommended so that the new device can be added to device collections (3 minutes by default, may need to be increased)")] = 180,
     use_existing_device: Annotated[str, typer.Option("--use-existing-device", "-d", help="[Optional] This option can be used to re-run SCCMSecrets.py using a previously registered device ; or to impersonate a legitimate SCCM client. In both cases, it expects the path of a folder containing a guid.txt file (the SCCM device GUID) and the key.pem file (the client's private key). Note that a client-name value must also be provided to SCCMSecrets (but does not have to match the one of the existing device)")] = None,
     pki_cert: Annotated[str, typer.Option("--pki-cert", "-c", help="[Optional] The path to a valid domain PKI certificate in PEM format. Required when the Management Point enforces HTTPS and thus client certificate authentication")] = None,
-    pki_key: Annotated[str, typer.Option("--pki-key", "-k", help="[Optional] The path to the private key of the certificate in PEM format")] = None,
+    pki_key: Annotated[str, typer.Option("--pki-key", "-pk", help="[Optional] The path to the private key of the certificate in PEM format")] = None,
     altauth: Annotated[bool, typer.Option("--altauth", "-a", help="[Optional] Use the MP's alternate authentication endpoint. This endpoint bypasses mutual TLS requirements, and automatically approves devices registered through it. It only works when the MP uses HTTPS AND HTTPS is enforced site-wide")] = False,
-    verbose: Annotated[bool, typer.Option("--verbose", "-v", help="[Optional] Enable verbose output")] = False
+    verbose: Annotated[bool, typer.Option("--verbose", "-v", help="[Optional] Enable verbose output")] = False,
+    kerberos: Annotated[bool, typer.Option("--kerberos", "-k", help="[Optional] Enable kerberos authentication. Uses GSSAPI or KRB5CCNAME.")] = False
 ):
     print_banner()
     if verbose is False: logging.basicConfig(format='%(message)s', level=logging.WARN)
@@ -102,7 +103,8 @@ def policies(
         machine_pass,
         pki_cert,
         pki_key,
-        altauth
+        altauth,
+        kerberos
     )
 
     if use_existing_device is None:
@@ -159,9 +161,10 @@ def files(
     urls: Annotated[str, typer.Option("--urls", "-f", help="[Optional] A file containing a list of URLs (one per line) that should be downloaded from the Distribution Point. This is useful if you already indexed files and do not want to download by extension, but rather specific known files")] = None,
     max_recursion: Annotated[int, typer.Option("--max-recursion", "-r", help="[Optional] The maximum recursion depth when indexing files from the Distribution Point")] = 10,
     pki_cert: Annotated[str, typer.Option("--pki-cert", "-c", help="[Optional] The path to a valid domain PKI certificate in PEM format. Required when the Distribution Point enforces HTTPS and thus client certificate authentication")] = None,
-    pki_key: Annotated[str, typer.Option("--pki-key", "-k", help="[Optional] The path to the private key of the certificate in PEM format")] = None,
+    pki_key: Annotated[str, typer.Option("--pki-key", "-pk", help="[Optional] The path to the private key of the certificate in PEM format")] = None,
     nocert: Annotated[bool, typer.Option("--nocert", "-n", help="[Optional] Use the DP's nocert endpoint. This endpoint bypasses mutual TLS requirements")] = False,
-    verbose: Annotated[bool, typer.Option("--verbose", "-v", help="[Optional] Enable verbose output")] = False
+    verbose: Annotated[bool, typer.Option("--verbose", "-v", help="[Optional] Enable verbose output")] = False,
+    kerberos: Annotated[bool, typer.Option("--kerberos", "-k", help="[Optional] Enable kerberos authentication. Uses GSSAPI or KRB5CCNAME.")] = False
 ):
     print_banner()
     if verbose is False: logging.basicConfig(format='%(message)s', level=logging.WARN)
@@ -232,7 +235,8 @@ def files(
         password ,
         pki_cert,
         pki_key,
-        nocert
+        nocert,
+        kerberos
     )
 
     try:

--- a/file_dumper.py
+++ b/file_dumper.py
@@ -7,6 +7,7 @@ import requests
 import traceback
 
 from requests_ntlm              import HttpNtlmAuth
+from requests_kerberos          import HTTPKerberosAuth
 from bs4                        import BeautifulSoup
 from conf                       import bcolors, ANONYMOUSDP, DP_DOWNLOAD_HEADERS
 
@@ -25,7 +26,8 @@ class FileDumper():
                  password,
                  pki_cert,
                  pki_key,
-                 nocert
+                 nocert,
+                 kerberos
                 ):
         self.distribution_point = distribution_point
         self.output_dir = output_dir
@@ -43,7 +45,9 @@ class FileDumper():
 
         self.session = requests.Session()
         self.session.headers.update(DP_DOWNLOAD_HEADERS)
-        if username is not None and password is not None:
+        if kerberos:
+            self.session.auth = HTTPKerberosAuth(force_preemptive=True)
+        elif username is not None and password is not None and not kerberos:
             self.session.auth = HttpNtlmAuth(username, password)
         if self.use_https:
             if nocert:

--- a/file_dumper.py
+++ b/file_dumper.py
@@ -46,7 +46,10 @@ class FileDumper():
         self.session = requests.Session()
         self.session.headers.update(DP_DOWNLOAD_HEADERS)
         if kerberos:
-            self.session.auth = HTTPKerberosAuth(force_preemptive=True)
+            if username:
+                principal, realm = username.split('@')
+                username = principal + '@' + realm.upper()
+            self.session.auth = HTTPKerberosAuth(force_preemptive=True, principal=username)
         elif username is not None and password is not None and not kerberos:
             self.session.auth = HttpNtlmAuth(username, password)
         if self.use_https:

--- a/policies_dumper.py
+++ b/policies_dumper.py
@@ -12,7 +12,7 @@ import xml.etree.ElementTree                as ET
 from cryptography.hazmat.primitives         import serialization
 from datetime                               import datetime
 from requests_ntlm                          import HttpNtlmAuth
-from requests_kerberos          import HTTPKerberosAuth
+from requests_kerberos                      import HTTPKerberosAuth
 from requests_toolbelt.multipart            import decoder
 from utils.crypto                           import create_private_key, create_certificate, SCCM_sign, build_MS_public_key_blob
 from utils.request_templates                import *

--- a/policies_dumper.py
+++ b/policies_dumper.py
@@ -12,6 +12,7 @@ import xml.etree.ElementTree                as ET
 from cryptography.hazmat.primitives         import serialization
 from datetime                               import datetime
 from requests_ntlm                          import HttpNtlmAuth
+from requests_kerberos          import HTTPKerberosAuth
 from requests_toolbelt.multipart            import decoder
 from utils.crypto                           import create_private_key, create_certificate, SCCM_sign, build_MS_public_key_blob
 from utils.request_templates                import *
@@ -34,7 +35,8 @@ class PoliciesDumper():
                  machine_pass,
                  pki_cert,
                  pki_key,
-                 altauth
+                 altauth,
+                 kerberos
                 ):
         self.management_point = management_point
         self.output_dir = output_dir
@@ -75,7 +77,9 @@ class PoliciesDumper():
         
         self.session = requests.Session()
         self.session.headers.update(MP_INTERACTIONS_HEADERS)
-        if machine_name is not None and machine_pass is not None and use_existing_device is None:
+        if kerberos:
+            self.session.auth = HTTPKerberosAuth(force_preemptive=True)
+        elif machine_name is not None and machine_pass is not None and use_existing_device is None:
             self.session.auth = HttpNtlmAuth(machine_name, machine_pass)
         if self.use_https:
             if altauth:

--- a/policies_dumper.py
+++ b/policies_dumper.py
@@ -78,7 +78,10 @@ class PoliciesDumper():
         self.session = requests.Session()
         self.session.headers.update(MP_INTERACTIONS_HEADERS)
         if kerberos:
-            self.session.auth = HTTPKerberosAuth(force_preemptive=True)
+            if machine_name:
+                principal, realm = machine_name.split('@')
+                machine_name = principal + '@' + realm.upper()
+            self.session.auth = HTTPKerberosAuth(force_preemptive=True, principal=machine_name)
         elif machine_name is not None and machine_pass is not None and use_existing_device is None:
             self.session.auth = HttpNtlmAuth(machine_name, machine_pass)
         if self.use_https:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ typer[all]
 bs4
 cryptography
 requests_ntlm
+requests_kerberos
 requests_toolbelt
 pyasn1_modules

--- a/utils/principal_format.py
+++ b/utils/principal_format.py
@@ -1,0 +1,3 @@
+def check_principal_format(principal_str: str):
+    principal, realm = principal_str.split('@')
+    return True if realm else False


### PR DESCRIPTION
Add the ability to use kerberos authentication to SCCM through the requests_kerberos auth adapter. This uses python-gssapi and works on windows and (probably linux). I noticed that KRB5CCNAME was ignored on windows in favor of using SSPI.

This PR also changes the short version of the existing `--pki-key` argument from ` -k`  to `-pk`, so that ` --kerberos` can be shortened to ` -k` in the impacket tradition.